### PR TITLE
Remove phpunit dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,6 @@
         "php": ">=5.3.0",
         "rmccue/requests": ">=1.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.7.*"
-    },
     "autoload": {
         "psr-4": {
             "Ipify\\": "src"


### PR DESCRIPTION
PHPUnit is mostly installed globally.

Require it would add superfluous and unwanted dev dependencies.
